### PR TITLE
Support custom separator between the number and the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ Then press `C-c l` when composing a message to add a link.
 - `message-links-link-header` : Default = `\n\n---links---\n` : Header use to separate links and the original text
 - `message-links-enable-link-header`: Default = `t` : Use `message-links-link-header` to separate links and the original text. If set to `nil`, links will be added at the end of the buffer.
 - `message-links-index-start` : Default = `1` : Start index of links. So by default the first link will be `[1]`.
+- `message-links-separator` : Default = ` : ` : The separator to use between the link index and the link text.

--- a/message-links.el
+++ b/message-links.el
@@ -22,6 +22,12 @@
   :type 'boolean
   :group 'message-links)
 
+(defcustom message-links-separator
+  " : "
+  "The text to place between the number and the link"
+  :type 'string
+  :group 'message-links)
+
 (defun message-links-add-link (link)
   "Insert the LINK under the text.
 The LINK will be added after the `message-links-link-header' if it is not
@@ -36,13 +42,16 @@ already present or added to the link list."
                 (progn ;; No message-links-link-header present in the message
                   (goto-char (point-max))
                   (insert message-links-link-header)
-                  (insert (concat "[" short-link-index "] : " link)))
+                  (insert (concat "[" short-link-index "]"
+                                  message-links-separator link)))
               (progn ;; Message found in the compose message
                 (goto-char (point-max))
-                (insert (concat "\n[" short-link-index "] : " link)))))
+                (insert (concat "\n[" short-link-index "]"
+                                message-links-separator link)))))
         (progn  ; Insert links without the link header
           (goto-char (point-max))
-          (insert (concat "\n[" short-link-index "] : " link)))))))
+          (insert (concat "\n[" short-link-index "]"
+                          message-links-separator link)))))))
 
 (defun message--links-get-max-short-link ()
   "Get the maximum index of the links in the buffer.
@@ -54,7 +63,10 @@ original text starts with '[0-9]*', this will be considered as a link"
   (let ((short-links '()))
     (save-excursion
       (goto-char (point-min))
-      (while (search-forward-regexp "^\\[\\([0-9]*\\)]" nil t)
+      (while (search-forward-regexp
+              (concat "^\\[\\([0-9]*\\)]"
+                      (regexp-quote message-links-separator))
+              nil t)
         (push (string-to-number (match-string-no-properties 1)) short-links)))
     (if short-links
       (apply #'max short-links)


### PR DESCRIPTION
This means the separator can be set to an arbitrary value, 

`[0] URL`
`[0]: URL`
`[0] : URL`

By setting the `message-links-separator` to ` `, `: ` or ` : `. Other arbitrary strings are supported too.