### PR TITLE
Cleanup: quiet checkdoc & package-lint warnings

### DIFF
--- a/message-links.el
+++ b/message-links.el
@@ -1,24 +1,45 @@
-;;; message-links.el -*- lexical-binding: t; -*-
+;;; message-links.el --- Manage reference links in text -*- lexical-binding: t; -*-
+
+;; SPDX-License-Identifier: MIT
+;; Copyright (C) 2022 Philippe Noel
+
+;; Author: Philippe Noel <philippe.noel@loria.fr>
+
+;; URL: https://github.com/PhilippeNoel1/message-links.el
+;; Version: 0.1
+;; Package-Requires: ((emacs "26.1"))
+
+;;; Commentary:
+
+;; Manage reference links.
+;;
+
+;;; Usage
+
+;; TODO.
+
+;;; Code:
+
 
 (defgroup message-links nil
-  "Manage reference links into text"
+  "Manage reference links into text."
   :group 'message)
 
 (defcustom message-links-link-header
   "\n\n---links---\n"
-  "Header used to separate links from the original text"
+  "Header used to separate links from the original text."
   :type 'string
   :group 'message-links)
 
 (defcustom message-links-index-start
   1
-  "Index of the first link inserted"
+  "Index of the first link inserted."
   :type 'integer
   :group 'message-links)
 
 (defcustom message-links-enable-link-header
   t
-  "Use the link header to separate original text from links"
+  "Use the link header to separate original text from links."
   :type 'boolean
   :group 'message-links)
 
@@ -28,7 +49,7 @@ The LINK will be added after the `message-links-link-header' if it is not
 already present or added to the link list."
   (interactive "sLink to insert: ")
   (save-excursion
-    (let ((short-link-index (number-to-string (1+ (message--links-get-max-short-link)))))
+    (let ((short-link-index (number-to-string (1+ (message-links--get-max-short-link)))))
       (insert (concat "[" short-link-index "]"))
       (if message-links-enable-link-header
           (progn ; Insert link after the link header
@@ -44,7 +65,7 @@ already present or added to the link list."
           (goto-char (point-max))
           (insert (concat "\n[" short-link-index "] : " link)))))))
 
-(defun message--links-get-max-short-link ()
+(defun message-links--get-max-short-link ()
   "Get the maximum index of the links in the buffer.
 Return the maximum value if links can be found in the buffer.
 Else, return `message-links-index-start' minus 1.
@@ -64,11 +85,11 @@ original text starts with '[0-9]*', this will be considered as a link"
 
 ;;;###autoload
 (define-minor-mode message-links-mode
-  "Toggle message-links-mode
+  "Toggle `message-links-mode'.
 
-Call `message-links-add' to add a link into you message buffer.
-"
+Call `message-links-add' to add a link into you message buffer."
   :lighter " message-links")
 ;;;###autoload
 
-(provide 'message-links-mode)
+(provide 'message-links)
+;;; message-links.el ends here


### PR DESCRIPTION
Cleanup the following warnings:

Checkdoc:

```
message-links.el:0: The first line should be of the form: ";;; package --- Summary"
message-links.el:0: You should have a section marked ";;; Commentary:"
message-links.el:3: You should have a section marked ";;; Code:"
message-links.el:74: The footer should be: (provide ’message-links)\n;;; message-links.el ends here
message-links.el:4: First sentence should end with punctuation
message-links.el:9: First sentence should end with punctuation
message-links.el:15: First sentence should end with punctuation
message-links.el:21: First sentence should end with punctuation
message-links.el:69: Documentation strings should not start or end with whitespace
message-links.el:67: First line is not a complete sentence
message-links.el:67: Lisp symbol ‘message-links-mode’ should appear in quotes
```

Package-Lint:

```
1:0: warning: "Version:" or "Package-Version:" header is missing. MELPA will handle this, but other archives will not.
1:0: error: Package should have a ;;; Commentary section.
1:0: error: Package should have a Homepage or URL header.
1:0: error: package.el cannot parse this buffer: Package lacks a file header
1:25: warning: You should depend on (emacs "24.1") if you need lexical-binding.
47:0: error: "message--links-get-max-short-link" doesn't start with package's prefix "message-links".
```
