### PR TITLE
Resolve warnings, use auto-loads, add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+
+test:
+	@emacs -batch -l tests/message-links-test.el -f ert-run-tests-batch-and-exit

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then press `C-c l` when composing a message to add a link.
 
 ## customization
 
-- `message-links-link-header` : Default = `\n\n---links---\n` : Header use to separate links and the original text. If set to `nil`, disable the header.
+- `message-links-link-header` : Default = `---links---` : Header use to separate links and the original text. If set to `nil`, disable the header.
 - `message-links-index-start` : Default = `1` : Start index of links. So by default the first link will be `[1]`.
 - `message-links-sep-footnotes-link` : Default = `'("[" . "] : " ` : The text to use for links in the bottom of the buffer. Default, links look like `[1] : link text`. Customize with `(setq message-links-sep-footnotes-link '("{^" . "}: "))` and links in footnote will look like `{^1}: link text`
 - `message-links-sep-text-link` : Default = `'("[" . "]")` : The text to use for links in the text. Default, links look like `blablabla [1] blablabla`. Customize with `(setq message-links-sep-text-link '("{^" . "}"))` and links in text will look like `blablabla {^1} blablabla`

--- a/message-links.el
+++ b/message-links.el
@@ -26,7 +26,7 @@
   :group 'message)
 
 (defcustom message-links-link-header
-  "\n\n---links---\n"
+  "---links---"
   "Header used to separate links from the original text.
 If set to nil, no header will be used."
   :type 'string
@@ -111,9 +111,13 @@ If the default is used, links in text looks like '[1]'"
      (message-links-link-header
       (cond
        ;; No message-links-link-header present in the message.
-       ((not (search-forward message-links-link-header nil t))
+       ((not (save-match-data
+               (re-search-forward
+                (message-links--gen-link-header-search-regex) nil t)))
         (message-links--goto-last-non-blank-eol)
-        (insert message-links-link-header)
+        (insert "\n\n"
+                message-links-link-header
+                "\n")
         (insert (message-links--gen-footnotes-link short-link-index)
                 link))
        ;; Message found in the compose message.
@@ -217,6 +221,13 @@ To be inserted in the body text."
    (car message-links-sep-text-link)
    index
    (cdr message-links-sep-text-link)))
+
+(defun message-links--gen-link-header-search-regex ()
+  "Generate the regex used to search for the header."
+  (concat
+   "^[:blank:]*"
+   (regexp-quote message-links-link-header)
+   "[:blank:]*$"))
 
 ;;; Public Functions (Auto-Loaded).
 

--- a/message-links.el
+++ b/message-links.el
@@ -109,19 +109,20 @@ If the default is used, links in text looks like '[1]'"
        ((not (search-forward message-links-link-header nil t))
         (goto-char (point-max))
         (insert message-links-link-header)
-        (insert (message-links--gen-footnotes-link short-link-index) link))
+        (insert (message-links--gen-footnotes-link short-link-index)
+                link))
        ;; Message found in the compose message.
        (t
         (goto-char (point-max))
-        (insert (concat "\n"
-                        (message-links--gen-footnotes-link short-link-index)
-                        link)))))
+        (insert "\n"
+                (message-links--gen-footnotes-link short-link-index)
+                link))))
      ;; Insert links without the link header.
      (t
       (goto-char (point-max))
-      (insert (concat "\n"
-                      (message-links--gen-footnotes-link short-link-index)
-                      link))))
+      (insert "\n"
+              (message-links--gen-footnotes-link short-link-index)
+              link)))
 
     ;; Leave the cursor after the link text (as if the user had typed it in).
     (goto-char pos-init)

--- a/message-links.el
+++ b/message-links.el
@@ -120,7 +120,14 @@ If the default is used, links in text looks like '[1]'"
         (insert "\n\n" message-links-link-header))))
      ;; No link header expected.
      (t
-      (message-links--goto-last-non-blank-eol)))
+      (message-links--goto-last-non-blank-eol)
+
+      ;; When inserting the first link without an explicit header:
+      ;; add a blank line separating links from non-link text
+      ;; (not essential but reads better).
+      (when (string-equal (number-to-string message-links-index-start)
+                          short-link-index)
+        (insert "\n"))))
 
     (insert "\n"
             (message-links--gen-footnotes-link short-link-index)

--- a/message-links.el
+++ b/message-links.el
@@ -48,8 +48,8 @@ Use the link header to separate original text from links."
 
 (defcustom message-links-sep-footnotes-link
   '("[" . "] : ")
-  "The text to use for links in the footnotes
-If the default is used, links in footnotes looks like '[1] : '"
+  "The text to use for links in the footnotes.
+If the default is used, links in footnotes looks like '[1] : '."
   :type 'alist
   :group 'message-links)
 
@@ -96,7 +96,7 @@ If the default is used, links in text looks like '[1]'"
   "Add LINK, returning the point where the link reference ends."
   (save-excursion
     (let ((short-link-index (number-to-string
-                             (1+ (message--links-get-max-footnote-link))))
+                             (1+ (message-links--get-max-footnote-link))))
           (pos-result nil))
       (insert (message-links--gen-text-link short-link-index))
       (setq pos-result (point))
@@ -204,7 +204,7 @@ Return a list of string or nil"
           (push (match-string-no-properties 0) footnote-links))))
     footnote-links))
 
-(defun message--links-get-max-footnote-link ()
+(defun message-links--get-max-footnote-link ()
   "Get the maximum index of the footnote links in the buffer.
 Return the maximum value if links can be found in the buffer.
 Else, return `message-links-index-start' minus 1."
@@ -228,14 +228,16 @@ Else, return `message-links-index-start' minus 1."
    (regexp-quote (cdr message-links-sep-footnotes-link))))
 
 (defun message-links--gen-footnotes-link (index)
-  "Generate the link to insert at the bottom (footnote) of the buffer"
+  "Generate the link prefix from INDEX.
+To be inserted at the bottom (footnote) of the buffer."
   (concat
    (car message-links-sep-footnotes-link)
    index
    (cdr message-links-sep-footnotes-link)))
 
 (defun message-links--gen-text-link (index)
-  "Generate the link to insert in the text."
+  "Generate the in-line link text from INDEX.
+To be inserted in the body text."
   (concat
    (car message-links-sep-text-link)
    index
@@ -243,4 +245,5 @@ Else, return `message-links-index-start' minus 1."
 
 (defalias 'message-links-add 'message-links-add-link)
 
+(provide 'message-links)
 ;;; message-links.el ends here

--- a/message-links.el
+++ b/message-links.el
@@ -106,32 +106,25 @@ If the default is used, links in text looks like '[1]'"
   (let ((short-link-index (number-to-string
                            (1+ (message-links--get-max-footnote-link))))
         (pos-init (point)))
+
     (cond
-     ;; Insert link after the link header if used.
      (message-links-link-header
+      ;; Ensure message-links-link-header present in the message (when non-nil).
       (cond
-       ;; No message-links-link-header present in the message.
-       ((not (save-match-data
-               (re-search-forward
-                (message-links--gen-link-header-search-regex) nil t)))
-        (message-links--goto-last-non-blank-eol)
-        (insert "\n\n"
-                message-links-link-header
-                "\n")
-        (insert (message-links--gen-footnotes-link short-link-index)
-                link))
-       ;; Message found in the compose message.
+       ((save-match-data
+          (re-search-forward
+           (message-links--gen-link-header-search-regex) nil t))
+        (message-links--goto-last-non-blank-eol))
        (t
         (message-links--goto-last-non-blank-eol)
-        (insert "\n"
-                (message-links--gen-footnotes-link short-link-index)
-                link))))
-     ;; Insert links without the link header.
+        (insert "\n\n" message-links-link-header))))
+     ;; No link header expected.
      (t
-      (message-links--goto-last-non-blank-eol)
-      (insert "\n"
-              (message-links--gen-footnotes-link short-link-index)
-              link)))
+      (message-links--goto-last-non-blank-eol)))
+
+    (insert "\n"
+            (message-links--gen-footnotes-link short-link-index)
+            link)
 
     ;; Leave the cursor after the link text (as if the user had typed it in).
     (goto-char pos-init)

--- a/message-links.el
+++ b/message-links.el
@@ -96,6 +96,11 @@ If the default is used, links in text looks like '[1]'"
 
 ;;; Private Implementations.
 
+(defun message-links--goto-last-non-blank-eol ()
+  "Move the cursor to the line ending of the last non-blank line."
+  (goto-char (point-max))
+  (skip-chars-backward "[:blank:]\n" (point-min)))
+
 (defun message-links--add-link-impl (link)
   "Add LINK, leaving the point where the link reference ends."
   (let ((short-link-index (number-to-string
@@ -107,19 +112,19 @@ If the default is used, links in text looks like '[1]'"
       (cond
        ;; No message-links-link-header present in the message.
        ((not (search-forward message-links-link-header nil t))
-        (goto-char (point-max))
+        (message-links--goto-last-non-blank-eol)
         (insert message-links-link-header)
         (insert (message-links--gen-footnotes-link short-link-index)
                 link))
        ;; Message found in the compose message.
        (t
-        (goto-char (point-max))
+        (message-links--goto-last-non-blank-eol)
         (insert "\n"
                 (message-links--gen-footnotes-link short-link-index)
                 link))))
      ;; Insert links without the link header.
      (t
-      (goto-char (point-max))
+      (message-links--goto-last-non-blank-eol)
       (insert "\n"
               (message-links--gen-footnotes-link short-link-index)
               link)))

--- a/tests/message-links-test.el
+++ b/tests/message-links-test.el
@@ -67,5 +67,16 @@
     "---links---\n"
     "[1] : https://www.gnu.org\n")))
 
+(ert-deftest link-single-no-header ()
+  "Convert a single link (without a header)."
+  (let ((message-links-link-header nil))
+    (message-links-test--convert-all-links-from-before-after
+     (list "Link to https://www.gnu.org page.\n")
+     (list
+      "Link to [1] page.\n"
+      "\n"
+      "[1] : https://www.gnu.org\n"))))
+
+
 (provide 'message-links-test)
 ;;; message-links-test.el ends here

--- a/tests/message-links-test.el
+++ b/tests/message-links-test.el
@@ -64,9 +64,8 @@
    (list
     "Link to [1] page.\n"
     "\n"
-    "\n"
     "---links---\n"
-    "[1] : https://www.gnu.org")))
+    "[1] : https://www.gnu.org\n")))
 
 (provide 'message-links-test)
 ;;; message-links-test.el ends here

--- a/tests/message-links-test.el
+++ b/tests/message-links-test.el
@@ -1,0 +1,72 @@
+;;; message-links-test.el --- Link utility test -*- lexical-binding: t -*-
+
+;; SPDX-License-Identifier: MIT
+;; Copyright (C) 2022 Philippe Noel
+
+;; Author: Philippe Noel <philippe.noel@loria.fr>
+
+;; URL: https://github.com/PhilippeNoel1/message-links.el
+;; Version: 0.1
+;; Package-Requires: ((emacs "26.1"))
+
+;;; Commentary:
+
+;; Manage reference links.
+;;
+
+;;; Usage
+
+;;
+;; To test this file run:
+;;
+;; emacs -batch -l tests/message-links-test.el -f ert-run-tests-batch-and-exit
+;;
+
+;;; Code:
+
+(require 'ert)
+
+;;; Setup Environment
+
+(setq message-links-basedir (concat (file-name-directory load-file-name) ".."))
+(add-to-list 'load-path message-links-basedir)
+(require 'message-links)
+
+;;; Test Utilities
+
+(defun message-links-test--do-convert-all-links ()
+  "Run a test on the current buffer using CHAR-ODD & CHAR-EVEN."
+  (message-links-convert-links-all)
+  (buffer-substring-no-properties (point-min) (point-max)))
+
+(defmacro message-links-test--convert-all-links-from-before-after (before after)
+  `(let ((buf (generate-new-buffer "message-links-test.txt")))
+     (let ((before-var ,before)
+           (after-var ,after))
+       (with-current-buffer buf
+         (apply 'insert before-var)
+         (let ((code-str-expect (apply 'concat after-var))
+               (code-str-result (message-links-test--do-convert-all-links)))
+           (should (equal code-str-expect code-str-result)))))))
+
+;;; Tests
+
+(ert-deftest link-nop ()
+  "Do Nothing."
+  (message-links-test--convert-all-links-from-before-after
+   (list "do nothing\n")
+   (list "do nothing\n")))
+
+(ert-deftest link-single ()
+  "Convert a single link."
+  (message-links-test--convert-all-links-from-before-after
+   (list "Link to https://www.gnu.org page.\n")
+   (list
+    "Link to [1] page.\n"
+    "\n"
+    "\n"
+    "---links---\n"
+    "[1] : https://www.gnu.org")))
+
+(provide 'message-links-test)
+;;; message-links-test.el ends here


### PR DESCRIPTION
Resolve warnings:

```
message-links.el:51: First line is not a complete sentence
message-links.el:231: First sentence should end with punctuation
message-links.el:231: Argument ‘index’ should appear (as INDEX) in the doc string
message-links.el:238: Argument ‘index’ should appear (as INDEX) in the doc string
207:0: error: "message--links-get-max-footnote-link" doesn't start with package's prefix "message-links".
```

-----

Add autoloads (so deferred loading can be used).

----

Add simple test (only for `message-links-convert-links-all`) at  the moment.

----

Leave the cursor after the newly inserted link (as if it were typed in).
_This seems like a better default behavior to me._


----

Fix white-space at the EOF, instead of moving to `point-max`, move to the end of the last non-blank line.

-----

Ensure blank line between link & non-link text when the first link is inserted (reads better).