### PR TITLE
README: wrap long lines at 119 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,26 +58,47 @@ Then press `C-c l` when composing a message to add a link.
 ## Commands
 
 - `message-links-add-link` enter a new link.
-- `message-links-convert-link-at-point` match a link at the cursor location, and convert it to a referenced link (this uses `message-links-match-link-at-point-fn` to identify links).
-- `message-links-convert-links-all` convert all links to references in the buffer or active region (using `message-links-match-link-forward-fn` to scan for links).
-- `message-links-renumber-all` re-number all links starting from `message-links-index-start`, putting the footnotes in order if necessary. This can be useful when editing paragraphs that contain links which may become un-ordered.
+- `message-links-convert-link-at-point` match a link at the cursor location, and convert it to a referenced link
+  (this uses `message-links-match-link-at-point-fn` to identify links).
+- `message-links-convert-links-all` convert all links to references in the buffer or active region
+  (using `message-links-match-link-forward-fn` to scan for links).
+- `message-links-renumber-all` re-number all links starting from `message-links-index-start`,
+  putting the footnotes in order if necessary. This can be useful when editing paragraphs that contain links which may
+  become un-ordered.
 
 ## customization
 
-- `message-links-link-header` : Default = `---links---` : Header use to separate links and the original text. If set to `nil`, disable the header.
-- `message-links-index-start` : Default = `1` : Start index of links. So by default the first link will be `[1]`.
-- `message-links-sep-footnotes-link` : Default = `'("[" . "] : " ` : The text to use for links in the bottom of the buffer. Default, links look like `[1] : link text`. Customize with `(setq message-links-sep-footnotes-link '("{^" . "}: "))` and links in footnote will look like `{^1}: link text`
-- `message-links-sep-text-link` : Default = `'("[" . "]")` : The text to use for links in the text. Default, links look like `blablabla [1] blablabla`. Customize with `(setq message-links-sep-text-link '("{^" . "}"))` and links in text will look like `blablabla {^1} blablabla`
-- `message-links-match-link-at-point-fn` : Defaults to using thing-at-pt (url). Return the bounds of the link at the point as a cons cell or nil.
-- `message-links-match-link-forward-fn` : Defaults to stepping over white-space for the next `message-links-match-link-at-point-fn`. Takes a single limit argument (representing a buffer position not to seek past), returns the bounds of the next link or nil when none are found.
-- `message-links-limit-range-fn` : Defaults to returning `((point-min) . (point-max))`. Use this to limit the range used for scanning and link insertion. Useful when writing commit messages which often show commented status text at the buffer end. Often it's preferable to add the links before these comments. For example, see ([FAQ](#faq)).
+- `message-links-link-header` : Default = `---links---` :<br>
+  Header use to separate links and the original text. If set to `nil`, disable the header.
+- `message-links-index-start` : Default = `1` :<br>
+  Start index of links. So by default the first link will be `[1]`.
+- `message-links-sep-footnotes-link` : Default = `'("[" . "] : " ` :<br>
+  The text to use for links in the bottom of the buffer. Default, links look like `[1] : link text`.
+  Customize with `(setq message-links-sep-footnotes-link '("{^" . "}: "))`
+  and links in footnote will look like `{^1}: link text`
+- `message-links-sep-text-link` : Default = `'("[" . "]")` :<br>
+  The text to use for links in the text. Default, links look like `blablabla [1] blablabla`.
+  Customize with `(setq message-links-sep-text-link '("{^" . "}"))` and links in text
+  will look like `blablabla {^1} blablabla`
+- `message-links-match-link-at-point-fn` : Defaults to using thing-at-pt (url).<br>
+  Return the bounds of the link at the point as a cons cell or nil.
+- `message-links-match-link-forward-fn` : Defaults to
+  stepping over white-space for the next `message-links-match-link-at-point-fn`.<br>
+  Takes a single limit argument (representing a buffer position not to seek past),
+  returns the bounds of the next link or nil when none are found.
+- `message-links-limit-range-fn` : Defaults to returning `((point-min) . (point-max))`.<br>
+  Use this to limit the range used for scanning and link insertion.
+  Useful when writing commit messages which often show commented status text at the buffer end.
+  Often it's preferable to add the links before these comments. For example, see ([FAQ](#faq)).
 
 
 # FAQ
 
 ## I don't want to put the links at the bottom of the buffer
 
-  If you work in a GIT/SVN message commit or a message with a lot of reply, you want your links at the bottom of your message and not the bottom of the buffer. Use `message-links-limit-range-fn` for this purpose:  
+  If you work in a GIT/SVN message commit or a message with a lot of reply,
+  you want your links at the bottom of your message and not the bottom of the buffer.
+  Use `message-links-limit-range-fn` for this purpose:
   By default:
   ``` text
   Hello,


### PR DESCRIPTION
Also add newlines after default values to visually separate them.